### PR TITLE
Update authors: Eliot McIntire as lead author and maintainer

### DIFF
--- a/fireSense_EscapePredict.R
+++ b/fireSense_EscapePredict.R
@@ -7,9 +7,9 @@ defineModule(sim, list(
                       "fire escape component of a landscape fire model (e.g., fireSense)."),
   keywords = c("escape probability", "fire frequency", "logistic", "fireSense"),
   authors = c(
+    person("Eliot", "McIntire", role = c("aut", "cre"), email = "eliot.mcintire@nrcan-rncan.gc.ca"),
+    person("Ian", "Eddy", role = "aut", email = "ian.eddy@nrcan-rncan.gc.ca"),
     person("Jean", "Marchal", email = "jean.d.marchal@gmail.com", role = "aut"),
-    person("Ian", "Eddy", role = c("aut", "cre"), email = "ian.eddy@nrcan-rncan.gc.ca"),
-    person("Eliot", "McIntire", role = "aut", email = "eliot.mcintire@nrcan-rncan.gc.ca"),
     person("Alex M", "Chubaty", role = "ctb", email = "achubaty@for-cast.ca")
   ),
   childModules = character(0),


### PR DESCRIPTION
Author metadata only — no code, no behaviour, no version change.

Eliot McIntire becomes lead author and maintainer (`aut`, `cre`); Jean Marchal
moves to last author. Existing middle authors keep their relative order, and
`ctb` entries are unchanged.

The rewritten `authors` block was evaluated through `utils::person()` to confirm
it parses and the roles come out as intended. `.Rmd` files render authors from
`moduleMetadata()` at build time, so they need no edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RhxSR6GHPvSqTBQ7y7pGL