### PR TITLE
ci: call the shared render-module-rmd workflow instead of a hand-rolled job

### DIFF
--- a/.github/workflows/render-module-rmd.yaml
+++ b/.github/workflows/render-module-rmd.yaml
@@ -1,3 +1,12 @@
+## Thin caller. The job itself lives in PredictiveEcology/actions, so the pins
+## for install-spatial-deps, install-Require, install-SpaDES and install-Rmd-pkgs
+## live there too and move once, instead of being frozen into every module
+## repository on the day it was created.
+##
+## https://github.com/PredictiveEcology/actions/blob/main/.github/workflows/render-module-rmd.yaml
+
+name: Render module Rmd
+
 on:
   pull_request:
     branches:
@@ -13,61 +22,17 @@ on:
       - .github/workflows/render-module-rmd.yaml
       - fireSense_EscapePredict.Rmd
       - fireSense_EscapePredict.R
-
-name: Render module Rmd
+  workflow_dispatch:
 
 jobs:
-  render:
-    name: Render module Rmd
-    runs-on: ubuntu-latest
-
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - name: Install other dependencies
-        run: |
-          sudo apt-get install -y \
-            libcurl4-openssl-dev \
-            libgit2-dev \
-            libglpk-dev \
-            libmagick++-dev \
-            libxml2-dev \
-            python3-gdal
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          Ncpus: 2
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-Require@v0.2
-        with:
-          GitTag: 'development'
-
-      - uses: PredictiveEcology/actions/install-SpaDES@v0.2
-
-      - uses: PredictiveEcology/actions/install-Rmd-pkgs@v0.2
-
-      - name: Install module package and other dependencies
-        run: |
-          pkgs <- SpaDES.core::packages(modules = "fireSense_EscapePredict", paths = "..")
-          Require::Require(pkgs[[1]])
-        shell: Rscript {0}
-
-      - name: Render module Rmd
-        run: |
-          rmarkdown::render("fireSense_EscapePredict.Rmd", encoding = "UTF-8")
-        shell: Rscript {0}
-
-      - name: Commit results
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-          git commit fireSense_EscapePredict.html -m 'Re-build fireSense_EscapePredict.Rmd' || echo "No changes to commit"
-          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{github.ref}} || echo "No changes to commit"
+  render-module-rmd:
+    ## The called workflow splits `render` (contents: read, which installs and
+    ## then executes this module's own code) from `commit` (contents: write,
+    ## which runs nothing but git). A called workflow can only reduce what is
+    ## granted here, never widen it, so the write scope has to be granted at the
+    ## call site.
+    permissions:
+      contents: write
+    uses: PredictiveEcology/actions/.github/workflows/render-module-rmd.yaml@main
+    with:
+      module: fireSense_EscapePredict


### PR DESCRIPTION
## Problem

"Render module Rmd" has been red on `development` since 2026-09-04 ([run 33907140331](https://github.com/PredictiveEcology/fireSense_EscapePredict/actions/runs/33907140331)), and on every pull request since, including #5. The job is a hand-rolled copy that pins `PredictiveEcology/actions/install-Require@v0.2`, and that step now fails:

```
Error in loadNamespace(x) : there is no package called 'remotes'
```

## Change

Replaces the job with the thin caller the other fireSense modules already use. It is copied verbatim from `fireSense_EscapeFit` with only the module name changed, and it calls `PredictiveEcology/actions/.github/workflows/render-module-rmd.yaml@main`. The spatial deps, `install-Require`, `install-SpaDES` and `install-Rmd-pkgs` pins now live in the actions repository and move once. The triggers are unchanged, plus `workflow_dispatch`.

The shared workflow separates `render` (`contents: read`), which runs the module's code, from `commit` (`contents: write`), which runs only git. That is why the caller grants `contents: write`.

This supersedes #3, which repoints `install-spatial-deps` inside the hand-rolled copy. Once this file is replaced, #3 has nothing left to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133867aFrmKtbhpNXasToP9
